### PR TITLE
Support simple assertion fmt argument.

### DIFF
--- a/src/assertion_failure.rs
+++ b/src/assertion_failure.rs
@@ -128,7 +128,7 @@ macro_rules! assertion_failure {
             $($(stringify!($key), $value,)+)?
             $($(
                 $crate::indent_write::indentable::Indented{
-                    item: format_args!($fmt_pattern $($fmt)+),
+                    item: format_args!($fmt_pattern $($fmt)*),
                     indent: "  ",
                 },
             )?)?
@@ -186,6 +186,19 @@ mod assertion_failure_tests {
             includes("     key: 10\n"),
             includes("long_key: 20\n"),
             includes("\n  Hello, World!")
+        );
+    }
+
+    #[test]
+    fn simple_trailing_fmt() {
+        assert_panics!(
+            assertion_failure!(
+                "Failure Message";
+                "Context around what/why we are checking"
+            ),
+            includes("assertion failed at"),
+            includes("Failure Message"),
+            includes("Context around what/why we are checking")
         );
     }
 


### PR DESCRIPTION
# Context

While adding some assertions with `assert_matches!` (and others) I sometimes want to add more context information as to why I'm checking the shape of my data and/or what I'm expecting to see. To this end, I tend to throw some explainer text at the end of my assertions to help understand the issue more quickly.

# Problem statement

I noticed macro expansion in `assertion_failure` doesn't accept a `fmt_pattern` without any `fmt` arguments. This means assertions that use it (like `assert_matches`) have the same limitation.

# Thought process

I think this should be fairly safe to swap from a `+` to a `*` but I encourage you to double check. I've added a test that fails without the change and succeeds with it. The change also didn't make any other tests start failing.

# Other thoughts

I noticed one of the tests (a doc test in assertion_failure.rs) is failing on main with stable (at least on macOS). I didn't fix that in this PR to keep things small and contained (and also because I haven't investigated if it behaves differently cross platform). FWIW, it's just a line number change so I wonder if it might be an edition/version issue 🤷.